### PR TITLE
Add option to engage hold behaviour immediately

### DIFF
--- a/lib/TapHoldManager.ahk
+++ b/lib/TapHoldManager.ahk
@@ -42,8 +42,8 @@ class KeyManager {
 	holdWatcherState := 0		; Are we potentially in a hold state?
 	tapWatcherState := 0		; Has a tap release occurred and another could possibly happen?
 	
-	holdActive := 0				; A hold was activated and we are waiting for the release
-	
+	fullHoldActive := 0
+
 	__New(manager, keyName, Callback, tapTime := -1, holdTime := -1, maxTaps := -1, prefixes := -1, window := ""){
 		this.manager := manager
 		this.Callback := Callback
@@ -168,7 +168,6 @@ class KeyManager {
 		this.SetFullHoldWatcherState(0)
 		this.SetTapWatcherState(0)
 		this.sequence := 0
-		this.holdActive := 0
 		this.fullHoldActive := 0
 	}
 	
@@ -200,12 +199,12 @@ class KeyManager {
 			; HOLD PRESS
 			fn := this.FireCallback.Bind(this, this.sequence, 1)
 			SetTimer, % fn, -0
-			this.holdActive := 1
 		}
 	}
 
+	; if this function fires, a key was held for longer than the tap timeout, so engage FULL hold mode
 	FullHoldWatcher(){
-		this.fullHoldActive := 1
+		this.fullHoldActive := this.state == 1
 	}
 	
 	; If this function fires, a key was released and we got to the end of the tap timeout, but no press was seen


### PR DESCRIPTION
First of all thanks for the repo! Looks sturdy and well written, a lot better than my personal attempts at this kind of behaviour in AHK! So I can only apologise for how much I've strayed away from the code style here, but I thought it would be a useful feature for other people.

### Problem

When you set up hold and tap behaviours for a key, and let's say your hold behaviour is to hold down the shift key. You want to be able to immediately press the button and get the shift behaviour, but you can't, because you have to wait out the timers.

Setting the hold time to 0 means the key is always in hold behaviour, so you never get the tap behaviour.

### Solution

Set the hold time to 0, but now this engages "soft hold"- The state sent to the callback function is that the key is in hold mode. However, internally there is now a "full hold" mode, which is only activated once the tap time has also been breached.

If you've made it to "full hold" state, and you release the key, you won't get a tap, but if you release before the full hold mode kicks in, you will.

All this time, hold mode has been active, so your attached functionality for hold mode has been available the whole time.

### Side notes

Now, obviously you won't always want this, if for e.g. you send a letter or symbol on hold, you don't want this to appear immediately, you want it to appear after the hold time, in which case you set your hold time >= tap time, and then you get existing behaviour.